### PR TITLE
Added Long to supported types

### DIFF
--- a/src/main/scala/zamblauskas/csv/parser/Reads.scala
+++ b/src/main/scala/zamblauskas/csv/parser/Reads.scala
@@ -17,6 +17,8 @@ object Reads {
 
   implicit val intReads: Reads[Int] = tryRead(_.toInt)
 
+  implicit val longReads: Reads[Long] = tryRead(_.toLong)
+
   implicit val floatReads: Reads[Float] = tryRead(_.toFloat)
 
   implicit val doubleReads: Reads[Double] = tryRead(_.toDouble)


### PR DESCRIPTION
Added Long to the list of supported "native" types that are implicitly converted from a .csv supplied string when trying to construct a case class type.